### PR TITLE
Update for FOSDEM 2026

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,13 +10,8 @@ The files are in `scripts/out` (one for Saturday, one for Sunday).
 _See requirements.txt_, in short:
  * Python 3
  * Jinja2
- * Pyyaml
 
 ### Generating the files
-To generate them yourself, follow the instructions on [the FOSDEM website](https://github.com/FOSDEM/website#exporting-from-fosdem-pentabarf)
-to generate a local export of the Pentabarf database (only available
-to FOSDEM staff), or use the provided (mostly current for 2022) `pentabarf.yaml` file.
-If you use your own local export, copy it to `scripts/pentabarf.yaml`.
 
 Execute `scripts/home_from_penta.py`. The generated files will be in
 `scripts/out`.

--- a/scripts/home_from_penta.py
+++ b/scripts/home_from_penta.py
@@ -4,7 +4,6 @@ from jinja2 import Environment, PackageLoader, select_autoescape
 from rapidfuzz import fuzz
 from track_parser import get_track_list
 import xml.etree.ElementTree as ET
-import json
 import requests
 
 class Room:

--- a/scripts/requirements.txt
+++ b/scripts/requirements.txt
@@ -1,4 +1,3 @@
-pyyaml
 Jinja2
 requests
 rapidfuzz

--- a/scripts/track_parser.py
+++ b/scripts/track_parser.py
@@ -1,5 +1,4 @@
 import requests
-import json
 from html.parser import HTMLParser
 
 class FOSDEMTrackParser(HTMLParser):

--- a/scripts/track_parser.py
+++ b/scripts/track_parser.py
@@ -8,7 +8,7 @@ class FOSDEMTrackParser(HTMLParser):
     def handle_starttag(self, tag, attrs):
         if tag == 'a':
             href = next((x for x in attrs if x[0] == "href"), None)
-            if href and href[1].startswith('/2025/schedule/track/'):
+            if href and "/schedule/track" in href[1]:
                 self.current_href = href[1]
 
     def handle_data(self, data):
@@ -19,7 +19,7 @@ class FOSDEMTrackParser(HTMLParser):
             self.track_list[data] = self.current_href
             self.current_href = None
 
-URL = "https://fosdem.org/2025/schedule/"
+URL = "https://fosdem.org/schedule/"
 
 def get_track_list():
     """


### PR DESCRIPTION
Update the codebase to work with the 2026 schedule, and generate the 2026 pages.

This PR removes any mention of the year, meaning that direct changes to the code will no longer be required for next year. Only the upstream schedule (hosted at https://fosdem.org/schedule/) will need to be updated.

I also removed a couple dependencies which were unused, and updated the generation instructions in the README.

TODO:

- [x] Incorporate the 2026 banner (to be provided by @ShinIce)
- [x] Generate the 2026 pages.