### PR TITLE
Give the banner an explicit size

### DIFF
--- a/scripts/out/saturday.html
+++ b/scripts/out/saturday.html
@@ -77,6 +77,14 @@
         margin-bottom: 0px;
     }
 
+    /* Banner */
+    .welcome svg {
+        display: block;
+        height: 12em;
+        width: 100%;
+        max-width: 1200px;
+    }
+
     .welcome_text {
         text-align: center;
     }

--- a/scripts/out/sunday.html
+++ b/scripts/out/sunday.html
@@ -77,6 +77,14 @@
         margin-bottom: 0px;
     }
 
+    /* Banner */
+    .welcome svg {
+        display: block;
+        height: 12em;
+        width: 100%;
+        max-width: 1200px;
+    }
+
     .welcome_text {
         text-align: center;
     }

--- a/scripts/templates/home.html.j2
+++ b/scripts/templates/home.html.j2
@@ -87,6 +87,14 @@
         margin-bottom: 0px;
     }
 
+    /* Banner */
+    .welcome svg {
+        display: block;
+        height: 12em;
+        width: 100%;
+        max-width: 1200px;
+    }
+
     .welcome_text {
         text-align: center;
     }


### PR DESCRIPTION
Fixes the 2026 banner not being visible on the generated HTML pages. This was happening due to the SVG not setting an explicit size (and the CSS not doing so either), resulting in the banner being 0x0 pixels.

We now add size guidance to the CSS, so the SVG no longer needs to specify it. The HTML pages were then regenerated.