### PR TITLE
Remove duplicate main tracks

### DIFF
--- a/scripts/home_from_penta.py
+++ b/scripts/home_from_penta.py
@@ -172,7 +172,6 @@ def schedule_from_penta(tracks):
                 url=track['url'],
                 track_slug=track_slug,
             )
-            my_schedule['main_tracks'].append(t)
         elif track_type == "devroom":
             t = DevRoom(
                 title=track['title'],

--- a/scripts/out/saturday.html
+++ b/scripts/out/saturday.html
@@ -428,13 +428,13 @@
                 <div class="card">
                     <div class="room_text">
                         <!--<img src="https://via.placeholder.com/32">-->
-                        <p>Main Track</p>
+                        <p>Main Track (K-building)</p>
                     </div>
                     <div class="room_subtext">
-                        <p><a href="https://www.fosdem.org/2026/schedule/track/main/" target="_blank" rel="noopener noreferrer">Schedule</a>
+                        <p><a href="https://www.fosdem.org/2026/schedule/track/main_k/" target="_blank" rel="noopener noreferrer">Schedule</a>
                         </p>
                     </div>
-                    <div class="btn"><a href="/#/room/#main:fosdem.org">
+                    <div class="btn"><a href="/#/room/#main_k:fosdem.org">
                         <div class="dark-panel button">Join Auditorium</div>
                     </a>
                     </div>

--- a/scripts/out/sunday.html
+++ b/scripts/out/sunday.html
@@ -428,13 +428,13 @@
                 <div class="card">
                     <div class="room_text">
                         <!--<img src="https://via.placeholder.com/32">-->
-                        <p>Main Track</p>
+                        <p>Main Track (K-building)</p>
                     </div>
                     <div class="room_subtext">
-                        <p><a href="https://www.fosdem.org/2026/schedule/track/main/" target="_blank" rel="noopener noreferrer">Schedule</a>
+                        <p><a href="https://www.fosdem.org/2026/schedule/track/main_k/" target="_blank" rel="noopener noreferrer">Schedule</a>
                         </p>
                     </div>
-                    <div class="btn"><a href="/#/room/#main:fosdem.org">
+                    <div class="btn"><a href="/#/room/#main_k:fosdem.org">
                         <div class="dark-panel button">Join Auditorium</div>
                     </a>
                     </div>


### PR DESCRIPTION
Replaces the following:

<img width="1847" height="666" alt="image" src="https://github.com/user-attachments/assets/4e6b45a1-de71-46ff-bf39-90e4854e6cb6" />

With this:

<img width="1804" height="657" alt="image" src="https://github.com/user-attachments/assets/f9584988-566d-4a22-aab8-448614a6e251" />

---

The diff is a bit confusing, as regenerating the tracks has also added the "Main Track K-Building", which was not present before. So the overall diff is that the second "Main Track" is now called "Main Track K-Building".
